### PR TITLE
Fix CartItem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ class CartItem(models.Model):
     product_code = models.TextField()
     product = Relationship(
         to=Product,
-        predicate=Q(product_code=L('sku')),
+        predicate=Q(sku=L('product_code')),
         multiple=False,
     )
 ```


### PR DESCRIPTION
Looks like the `CartItem` example in README had the field names inverted. This change makes it reflect [the code in the tests](https://github.com/AlexHill/django-relativity/blob/master/tests/testapp/models.py#L113).