### PR TITLE
Add Django 2.2 & 3.0 support. Thanks to @OskarPersson for investigating.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   global:
     - DJANGO_SETTINGS_MODULE=tests.settings
   matrix:
+    - DJANGO_VERSION=3.0
+    - DJANGO_VERSION=2.2
     - DJANGO_VERSION=2.1
     - DJANGO_VERSION=2.0
     - DJANGO_VERSION=1.11
@@ -19,12 +21,26 @@ matrix:
        env: DJANGO_VERSION=2.0
      - python: "2.7"
        env: DJANGO_VERSION=2.1
+     - python: "2.7"
+       env: DJANGO_VERSION=2.2
+     - python: "2.7"
+       env: DJANGO_VERSION=3.0
      - python: "pypy"
        env: DJANGO_VERSION=2.0
      - python: "pypy"
        env: DJANGO_VERSION=2.1
+     - python: "pypy"
+       env: DJANGO_VERSION=2.2
+     - python: "pypy"
+       env: DJANGO_VERSION=3.0
      - python: "3.4"
        env: DJANGO_VERSION=2.1
+     - python: "3.4"
+       env: DJANGO_VERSION=2.2
+     - python: "3.4"
+       env: DJANGO_VERSION=3.0
+     - python: "3.5"
+       env: DJANGO_VERSION=3.0
 install:
   - pip install -r test-requirements.txt
   - pip install "django==$DJANGO_VERSION.*"

--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -76,6 +76,7 @@ class Restriction(object):
 
 def create_relationship_many_manager(base_manager, rel):
 
+    # noinspection PyProtectedMember
     class RelationshipManager(base_manager):
 
         def __init__(self, instance):
@@ -101,9 +102,6 @@ def create_relationship_many_manager(base_manager, rel):
             if self._db:
                 queryset = queryset.using(self._db)
             queryset = queryset.filter(**self.core_filters)
-            queryset._known_related_objects = {
-                self.field: {self.instance.pk: self.instance}
-            }
             return queryset
 
         def _remove_prefetched_objects(self):
@@ -261,19 +259,18 @@ class CustomForeignObjectRel(ForeignObjectRel):
             return {self.name: obj}
 
 
+# noinspection PyProtectedMember
 class ManyToManyRelationshipDescriptor(ReverseManyToOneDescriptor):
-
     @cached_property
     def related_manager_cls(self):
         related_model = self.rel.related_model
-
         manager = create_relationship_many_manager(
             related_model._default_manager.__class__, self.rel
         )
-
         return manager
 
 
+# noinspection PyProtectedMember
 class Relationship(models.ForeignObject):
     """
     This is a Django model field.
@@ -383,10 +380,10 @@ class Relationship(models.ForeignObject):
 
 
 class L(F):
-
     def resolve_expression(
-        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
+        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False, simple_col=False,
     ):
+        # noinspection PyProtectedMember
         return super(L, self).resolve_expression(
             query._relationship_field_query, allow_joins, reuse, summarize, for_save
         )

--- a/relativity/mptt.py
+++ b/relativity/mptt.py
@@ -5,12 +5,12 @@ from relativity.fields import L, Relationship
 class MPTTRef(L):
 
     def resolve_expression(
-        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
+        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False, simple_col=False
     ):
         model = query._relationship_field_query.model
         name = getattr(model._mptt_meta, self.name + "_attr")
         return L(name).resolve_expression(
-            query, allow_joins, reuse, summarize, for_save
+            query, allow_joins, reuse, summarize, for_save, simple_col
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/alexhill/django-relativity',
     packages=setuptools.find_packages(),
-    install_requires=['django>=1.11'],
+    install_requires=['django>=1.11', 'six'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, unicode_literals
 from django.db import models
 from django.db.models import Lookup
 from django.db.models.fields import Field
-from django.utils.encoding import python_2_unicode_compatible
 from mptt.fields import TreeForeignKey
 from mptt.models import MPTTModel
+from six import python_2_unicode_compatible
 from treebeard.mp_tree import MP_Node
 from treebeard.ns_tree import NS_Node
 


### PR DESCRIPTION
Django 2.2+ breaks when _known_related_objects is populated by a Relationship. By not populating it we skip the breaking code, and it turned out populating it always resulted in a caught and ignored exception in Django in earlier versions, so removing it can't hurt.