### PR TITLE
Fix prefetch query for Postgres

### DIFF
--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -145,7 +145,7 @@ def create_relationship_many_manager(base_manager, rel):
                 select={
                     "_prefetch_related_val_%s"
                     % f.attname: "%s.%s"
-                    % (qn(join_table), qn(f.column))
+                    % (join_table, qn(f.column))
                     for f in [pk]
                 }
             )


### PR DESCRIPTION
Fixes #7

Postgres requires the alias declaration and usage to be either both quoted or both non-quoted. This can be seen in this dbfiddle: https://dbfiddle.uk/?rdbms=postgres_12&fiddle=856f6c7ac95082949b633251dccdd638

To solve this I have simply removed the quotes from the SELECT-clause but this could also be solved by adding quotes to the creation of the alias instead.

I've tested the changes against PostgreSQL, SQLite, MySQL and MariaDB and all the tests passes (aside from the notes in #7 but that is because of the tests, not the library itself)
