### PR TITLE
For now, don't cache related values

### DIFF
--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -289,6 +289,14 @@ class SingleRelationshipDescriptor(ReverseOneToOneDescriptor):
                 return None
             else:
                 raise
+        finally:
+            # TODO: figure out how to persuade Django to treat us a normal related_object
+            if django.VERSION < (2,):
+                if hasattr(instance, self.cache_name):
+                    delattr(instance, self.cache_name)
+            else:
+                if self.related.is_cached(instance):
+                    self.related.delete_cached_value(instance)
 
 
 # noinspection PyProtectedMember

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -345,13 +345,16 @@ class RelationshipTests(TestCase):
 
     def test_single_reverse(self):
         node_1 = LinkedNode.objects.create(
-            name="first node", prev_id=None,
+            name="first node",
+            prev_id=None,
         )
         node_2 = LinkedNode.objects.create(
-            name="next node", prev_id=node_1.id,
+            name="next node",
+            prev_id=node_1.id,
         )
         node_3 = LinkedNode.objects.create(
-            name="last node", prev_id=node_2.id,
+            name="last node",
+            prev_id=node_2.id,
         )
         self.assertEqual(node_3.prev, node_2)
         self.assertEqual(node_1.next, node_2)
@@ -371,3 +374,11 @@ class RelationshipTests(TestCase):
     def test_complex_expression(self):
         ug = UserGenerator.objects.create()
         self.assertEqual(ug.user, User.objects.get(username="generated_for_%d" % ug.id))
+
+    def test_descriptor_not_cached(self):
+        item = CartItem.objects.first()
+        self.assertIsNotNone(item.product)
+
+        item.product.delete()
+        with self.assertRaises(Product.DoesNotExist):
+            item.product


### PR DESCRIPTION
When doing refresh_from_db(), Django only looks at obj._meta.concrete_fields and obj._meta.related_objects when assessing which caches to bust. In cases where Relationship provides a single object descriptor, we currently thread the needle between these two sets - Django considers us neither a related object nor a concrete field - and so the field cache is never cleared. For now, solve this by never allowing related objects to be cached.