### PR TITLE
django 4 compatibility

### DIFF
--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -24,7 +24,6 @@ class Restriction(object):
         local_alias,
         related_alias,
         predicate,
-        where_class,
     ):
         self.forward = forward
         self.local_model = local_model
@@ -32,7 +31,6 @@ class Restriction(object):
         self.related_alias = related_alias
         self.local_alias = local_alias
         self.predicate = predicate
-        self.where_class = where_class
 
     def as_sql(self, compiler, connection):
         local, related = self.local_alias, self.related_alias
@@ -227,7 +225,7 @@ class CustomForeignObjectRel(ForeignObjectRel):
     def relationship_related_query_name(self):
         return self.remote_field.name
 
-    def get_extra_restriction(self, where_class, alias, related_alias):
+    def get_extra_restriction(self, alias, related_alias):
         return Restriction(
             forward=False,
             local_model=self.related_model,
@@ -235,7 +233,6 @@ class CustomForeignObjectRel(ForeignObjectRel):
             local_alias=related_alias,
             related_alias=alias,
             predicate=self.field.predicate,
-            where_class=where_class,
         )
 
     @classmethod
@@ -354,7 +351,7 @@ class Relationship(models.ForeignObject):
     def get_accessor_name(self):
         return self.name
 
-    def get_extra_restriction(self, where_class, related_alias, local_alias):
+    def get_extra_restriction(self, related_alias, local_alias):
         return Restriction(
             forward=True,
             local_model=self.model,
@@ -362,7 +359,6 @@ class Relationship(models.ForeignObject):
             local_alias=local_alias,
             related_alias=related_alias,
             predicate=self.predicate,
-            where_class=where_class,
         )
 
     def get_forward_related_filter(self, obj):

--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -225,7 +225,7 @@ class CustomForeignObjectRel(ForeignObjectRel):
     def relationship_related_query_name(self):
         return self.remote_field.name
 
-    def get_extra_restriction(self, alias, related_alias):
+    def _get_extra_restriction(self, alias, related_alias):
         return Restriction(
             forward=False,
             local_model=self.related_model,
@@ -234,6 +234,18 @@ class CustomForeignObjectRel(ForeignObjectRel):
             related_alias=alias,
             predicate=self.field.predicate,
         )
+
+    def _get_extra_restriction_legacy(self, where_class, alias, related_alias):
+        # this is a shim to maintain compatibility with django < 4.0
+        return self._get_extra_restriction(alias, related_alias)
+
+    # this is required to handle a change in Django 4.0
+    # https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
+    # the signature of the (private) funtion was changed
+    if django.VERSION < (4, 0):
+        get_extra_restriction = _get_extra_restriction_legacy
+    else:
+        get_extra_restriction = _get_extra_restriction
 
     @classmethod
     def _resolve_expression_local_references(cls, expr, obj):
@@ -351,7 +363,7 @@ class Relationship(models.ForeignObject):
     def get_accessor_name(self):
         return self.name
 
-    def get_extra_restriction(self, related_alias, local_alias):
+    def _get_extra_restriction(self, related_alias, local_alias):
         return Restriction(
             forward=True,
             local_model=self.model,
@@ -360,6 +372,19 @@ class Relationship(models.ForeignObject):
             related_alias=related_alias,
             predicate=self.predicate,
         )
+
+    def _get_extra_restriction_legacy(self, where_class, alias, related_alias):
+        # this is a shim to maintain compatibility with django < 4.0
+        return self._get_extra_restriction(alias, related_alias)
+
+    # this is required to handle a change in Django 4.0
+    # https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
+    # the signature of the (private) funtion was changed
+    if django.VERSION < (4, 0):
+        get_extra_restriction = _get_extra_restriction_legacy
+    else:
+        get_extra_restriction = _get_extra_restriction
+
 
     def get_forward_related_filter(self, obj):
         """


### PR DESCRIPTION
According to django 4's [release notes](https://docs.djangoproject.com/en/dev/releases/4.0/#miscellaneous), the `where_class` argument has been removed `ForeignObject` and `ForeignObjectRel`,
> The where_class property of django.db.models.sql.query.Query and the where_class argument to the private get_extra_restriction() method of ForeignObject and ForeignObjectRel are removed. If needed, initialize django.db.models.sql.where.WhereNode instead.

I patched the method for backwards compatibility, copying from https://github.com/jazzband/django-taggit/pull/778, tests still pass and my 4.0 project now works, so hopefully that's all we need for django 4 😄 
