### PR TITLE
Support negated filters on one-to-one and many-to-one Relationships

### DIFF
--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -405,12 +405,12 @@ class Relationship(models.ForeignObject):
         if django.VERSION < (2, 0):
             to_opts = self.rel.to._meta
             from_opts = self.model._meta
-            return [PathInfo(from_opts, to_opts, (to_opts.pk,), self, True, False)]
+            return [PathInfo(from_opts, to_opts, (to_opts.pk,), self, self.multiple, False)]
         to_opts = self.remote_field.model._meta
         from_opts = self.model._meta
         return [
             PathInfo(
-                from_opts, to_opts, (to_opts.pk,), self, True, False, filtered_relation
+                from_opts, to_opts, (to_opts.pk,), self, self.multiple, False, filtered_relation
             )
         ]
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -364,6 +364,29 @@ class RelationshipTests(TestCase):
         self.assertIsNone(node_3.next)
         self.assertIsNone(node_1.prev)
 
+    def test_many_to_one_exclude_forward(self):
+        qs = CartItem.objects.exclude(product__colour="red")
+
+        self.assertEqual(qs.count(), 1)
+
+    def test_single_exclude_forward(self):
+        node_1 = LinkedNode.objects.create(
+            name="first node",
+            prev_id=None,
+        )
+        node_2 = LinkedNode.objects.create(
+            name="next node",
+            prev_id=node_1.id,
+        )
+        node_3 = LinkedNode.objects.create(
+            name="last node",
+            prev_id=node_2.id,
+        )
+
+        qs = LinkedNode.objects.exclude(next__name__contains="last")
+
+        self.assertEqual(qs.count(), 2)
+
     def test_not_nullable(self):
         item = CartItem.objects.create(
             pk=4,


### PR DESCRIPTION
This makes it possible to have a one-to-one and many-to-one `Relationship` with both `multiple` set to `False` and execute negated queries on it. This sort of relationship does not need to create a `WHERE NOT EXIST` subquery, and by setting the `m2m` variable the ORM will generate the correct query for us.

This does not solve the larger issue for a one-to-many or many-to-many relationship and negated queries.