### PR TITLE
Add support for Django 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           - postgres://postgres:postgres@postgres/django_relativity
           - sqlite://
           - mysql://root:mysql@mysql/django_relativity
-        django_version: ["3.2", "4.0", "4.1", "4.2"]
+        django_version: ["3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2"]
         python_version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - {django_version: "3.2", python_version: "3.6", database_url: "postgres://postgres:postgres@postgres/django_relativity"}
@@ -23,6 +23,12 @@ jobs:
         exclude:
           - {django_version: "3.2", python_version: "3.11"}
           - {django_version: "4.0", python_version: "3.11"}
+          - {django_version: "5.0", python_version: "3.8"}
+          - {django_version: "5.0", python_version: "3.9"}
+          - {django_version: "5.1", python_version: "3.8"}
+          - {django_version: "5.1", python_version: "3.9"}
+          - {django_version: "5.2", python_version: "3.8"}
+          - {django_version: "5.2", python_version: "3.9"}
     runs-on: ubuntu-latest
     container: python:${{ matrix.python_version }}
     steps:

--- a/relativity/fields.py
+++ b/relativity/fields.py
@@ -360,6 +360,10 @@ class Relationship(models.ForeignObject):
         """
         return self.remote_field
 
+    @cached_property
+    def accessor_name(self):
+        return self.get_accessor_name()
+
     def get_accessor_name(self):
         return self.name
 


### PR DESCRIPTION
This makes changes and adds testing for Django 5.0, 5.1, and 5.2.

A new cached property called `accessor_name` was added in 5.2 for performance improvements that this package needs to mimic. This uses the same value as `get_accessor_name`, which is how it is also implemented in core.

See: https://code.djangoproject.com/ticket/35230